### PR TITLE
Add style map rule to match Word-style quotations

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const convert = ( filePath ) => {
 	// @TODO determine if Word uses the same style name for block quotations.
 	const options = {
 		styleMap: [
-			"p[style-name='Quotations'] => gblockquote"
+			"p[style-name='Quotations'] => gblockquote",
+			"p[style-name='Quote'] => gblockquote",
 		]
 	};
 


### PR DESCRIPTION
Microsoft Word uses "Quote" instead of "Quotation" to denote block quotations. Add a style map rule to map this to 'gblockquote' custom tag.