### PR TITLE
Add a build script specifically for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,23 @@ If you prefer to use Git to keep the NC Doc Converter up to date, you can instea
 
 ## How to Use
 
+### MacOS and Linux
+
 1. Move the docx files you want to convert into the `input` folder in the NC Doc Converter folder (which will be called "doc-converter-x.x.x" or "doc-converter" by default).
-2. The NC Doc Converter must be run from a terminal. Open a terminal in the Doc Converter directory. (The shortcut for this is to double-click on the File Explorer address bar or press `alt` + `d`, and then type `cmd` and press enter.)
+2. The NC Doc Converter must be run from a terminal. Open a terminal in the Doc Converter directory.
 3. Run the command `npm run NCconvert`
 4. You should now find html files in the `output` directory corresponding to the docx files in the `input` directory.
 5. You can run the `NCconvert` npm command multiple times with the same files. The output file will be overwritten.
 6. To clean up you can either manually remove the input and output files, or you can run the command `npm run clean` to delete all of the files in both input and output directories.
+
+### Windows
+
+1. Move the docx files you want to convert into the `input` folder in the NC Doc Converter folder (which will be called "doc-converter-x.x.x" or "doc-converter" by default).
+2. The NC Doc Converter must be run from a terminal. Open a terminal in the Doc Converter directory. The shortcut for this is to double-click on the File Explorer address bar or press `alt` + `d`, and then type `cmd` and press enter.
+3. Run the command `npm run NCconvertwin`
+4. You should now find html files in the `output` directory corresponding to the docx files in the `input` directory.
+5. You can run the `NCconvertwin` npm command multiple times with the same files. The output file will be overwritten.
+6. To clean up you can manually remove the input and output files. (The `clean` script does not work in Windows at this time.)
 
 ## Updating
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"scripts": {
 		"NCconvert": "./index.js",
+		"NCconvertwin": "node index.js",
 		"lint:pkg": "npmPkgJsonLint .",
 		"clean:input": "rimraf input/*",
 		"clean:output": "rimraf output/*",


### PR DESCRIPTION
Windows does not cooperate well with `./`-style script calls. Add a build script specifically for Windows that explicitly tells Windows to run the index script with node.